### PR TITLE
Remove @types/glob and bump VSCode engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.1.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@types/glob": "^9.0.0",
         "@types/node": "^25.6.0",
         "@types/vscode": "^1.118.0",
         "@vscode/vsce": "^3.1.1",
@@ -18,7 +17,7 @@
       "engines": {
         "node": ">=20",
         "npm": ">=10",
-        "vscode": "^1.94.0"
+        "vscode": "^1.118.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -553,17 +552,6 @@
       "license": "MIT",
       "dependencies": {
         "@textlint/ast-node-types": "15.6.0"
-      }
-    },
-    "node_modules/@types/glob": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-9.0.0.tgz",
-      "integrity": "sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==",
-      "deprecated": "This is a stub types definition. glob provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "*"
       }
     },
     "node_modules/@types/node": {
@@ -4282,15 +4270,6 @@
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "15.6.0"
-      }
-    },
-    "@types/glob": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-9.0.0.tgz",
-      "integrity": "sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==",
-      "dev": true,
-      "requires": {
-        "glob": "13.0.6"
       }
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "engines": {
     "node": ">=20",
     "npm": ">=10",
-    "vscode": "^1.94.0"
+    "vscode": "^1.118.0"
   },
   "license": "GPL-3.0-or-later",
   "icon": "images/menubar-plus.png",
@@ -943,7 +943,6 @@
     "package": "npx --no-install vsce package"
   },
   "devDependencies": {
-    "@types/glob": "^9.0.0",
     "@types/node": "^25.6.0",
     "@types/vscode": "^1.118.0",
     "@vscode/vsce": "^3.1.1",


### PR DESCRIPTION
Update package.json and package-lock.json: remove the devDependency @types/glob (and its lockfile entries) and update the VS Code engine range from ^1.94.0 to ^1.118.0. This aligns the extension with newer VS Code typings and removes an unnecessary stub types package from the dependency graph.