### PR TITLE
Skip manifest rewrites in extension dev host

### DIFF
--- a/src/configuratorWebview.ts
+++ b/src/configuratorWebview.ts
@@ -26,6 +26,10 @@ export interface ConfiguratorHtmlInput {
   codicons: readonly string[];
 }
 
+export interface ConfiguratorCommandOptions {
+  allowExtensionFileMutation?: boolean;
+}
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -526,7 +530,12 @@ function clearConfiguratorButtonSave(): void {
   pendingConfiguratorButtonSave = false;
 }
 
-export function registerConfiguratorCommand(context: ExtensionContext): void {
+export function registerConfiguratorCommand(
+  context: ExtensionContext,
+  options: ConfiguratorCommandOptions = {}
+): void {
+  const allowExtensionFileMutation = options.allowExtensionFileMutation ?? true;
+
   context.subscriptions.push(
     commands.registerCommand('ShortcutMenuBarPlus.configureButtons', () => {
       let before = currentButtons();
@@ -597,6 +606,17 @@ export function registerConfiguratorCommand(context: ExtensionContext): void {
           );
           return;
         }
+
+        if (!allowExtensionFileMutation) {
+          if (needsReload) {
+            clearConfiguratorButtonSave();
+          }
+          before = next;
+          reloadPending = false;
+          await panel.webview.postMessage({ type: 'saved', needsReload: false });
+          return;
+        }
+
         const iconsApplied = applyUserButtonIcons(next, context.extensionPath);
         const manifestApplied = applyButtonManifest(next, context.extensionPath, {
           visibilityMode: 'structured',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import {
   Disposable,
   env,
   ExtensionContext,
+  ExtensionMode,
   extensions,
   Uri,
   window,
@@ -160,7 +161,10 @@ export function activate(context: ExtensionContext) {
 
   // show notification on major release
   showWhatsNew(context);
-  registerConfiguratorCommand(context);
+  const canMutateExtensionFiles = context.extensionMode !== ExtensionMode.Development;
+  registerConfiguratorCommand(context, {
+    allowExtensionFileMutation: canMutateExtensionFiles,
+  });
 
   // rest of code
   // Step: If simple commands then add to this array
@@ -344,14 +348,20 @@ export function activate(context: ExtensionContext) {
   // Re-apply user button icons and names from current model (restores after extension updates)
   const extensionPath = context.extensionPath;
   let appliedButtons = cachedButtons.configuredButtons;
-  const startupApplied = applyUserButtonModel(
-    appliedButtons,
-    extensionPath,
-    cachedButtons.hasStructuredButtons ? "structured" : "legacy"
-  );
-  if (!startupApplied) {
-    console.error(
-      "[ShortcutMenuBarPlus] Startup button model application was incomplete."
+  if (canMutateExtensionFiles) {
+    const startupApplied = applyUserButtonModel(
+      appliedButtons,
+      extensionPath,
+      cachedButtons.hasStructuredButtons ? "structured" : "legacy"
+    );
+    if (!startupApplied) {
+      console.error(
+        "[ShortcutMenuBarPlus] Startup button model application was incomplete."
+      );
+    }
+  } else {
+    console.info(
+      "[ShortcutMenuBarPlus] Running in extension development mode; skipping package.json and generated icon file updates."
     );
   }
 
@@ -365,6 +375,10 @@ export function activate(context: ExtensionContext) {
       if (e.affectsConfiguration("ShortcutMenuBarPlus.buttons")) {
         const nextButtons = refreshCachedButtons();
         if (consumeConfiguratorButtonSave()) {
+          appliedButtons = nextButtons;
+          return;
+        }
+        if (!canMutateExtensionFiles) {
           appliedButtons = nextButtons;
           return;
         }
@@ -391,6 +405,9 @@ export function activate(context: ExtensionContext) {
           !cachedButtons.hasStructuredButtons &&
           e.affectsConfiguration(`ShortcutMenuBarPlus.userButton${idx}Icon`)
         ) {
+          if (!canMutateExtensionFiles) {
+            continue;
+          }
           const icon = config.get<string>(`userButton${idx}Icon`);
           let iconApplied = false;
           if (icon) {
@@ -419,6 +436,9 @@ export function activate(context: ExtensionContext) {
           !cachedButtons.hasStructuredButtons &&
           e.affectsConfiguration(`ShortcutMenuBarPlus.userButton${idx}Name`)
         ) {
+          if (!canMutateExtensionFiles) {
+            continue;
+          }
           const name = config.get<string>(`userButton${idx}Name`) ?? null;
           let nameApplied = false;
           try {
@@ -439,6 +459,10 @@ export function activate(context: ExtensionContext) {
           BUILTIN_BUTTONS.some((button) =>
             e.affectsConfiguration(`ShortcutMenuBarPlus.${button.id}`)
           );
+      }
+
+      if (!canMutateExtensionFiles) {
+        return;
       }
 
       if (legacyVisibilityChanged && !cachedButtons.hasStructuredButtons) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -462,6 +462,9 @@ export function activate(context: ExtensionContext) {
       }
 
       if (!canMutateExtensionFiles) {
+        if (legacyVisibilityChanged && !cachedButtons.hasStructuredButtons) {
+          appliedButtons = refreshCachedButtons();
+        }
         return;
       }
 

--- a/tests/extensionConfigurator.test.ts
+++ b/tests/extensionConfigurator.test.ts
@@ -11,6 +11,11 @@ jest.mock(
       Workspace: 2,
     },
     Disposable: jest.fn(),
+    ExtensionMode: {
+      Production: 1,
+      Development: 2,
+      Test: 3,
+    },
     env: {
       openExternal: jest.fn(),
     },
@@ -153,6 +158,119 @@ describe('extension configurator integration', () => {
 
     expect(applyButtonManifest).toHaveBeenCalledTimes(2);
     expect(window.showInformationMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mutate package or icon files while running from the extension development host', async () => {
+    let buttonsValue: unknown;
+    const config = {
+      inspect: jest.fn(() =>
+        buttonsValue === undefined
+          ? { defaultValue: [] }
+          : { defaultValue: [], globalValue: buttonsValue }
+      ),
+      get: jest.fn((key: string) => {
+        if (key === 'buttons') {
+          return buttonsValue;
+        }
+        if (key === 'userButton01Icon') {
+          return 'tools';
+        }
+        if (key === 'userButton01Name') {
+          return 'Dev Name';
+        }
+        return undefined;
+      }),
+      update: jest.fn(async (_key: string, value: unknown) => {
+        buttonsValue = value;
+      }),
+    };
+    const registeredCommands = new Map<string, (...args: unknown[]) => unknown>();
+    let configChangeHandler:
+      | ((event: { affectsConfiguration: (section: string) => boolean }) => void)
+      | undefined;
+    let messageHandler: ((message: unknown) => Promise<void>) | undefined;
+    const panel = {
+      webview: {
+        asWebviewUri: jest.fn((uri: { fsPath: string }) => ({
+          toString: () => `vscode-resource:${uri.fsPath}`,
+        })),
+        cspSource: 'vscode-resource:',
+        html: '',
+        onDidReceiveMessage: jest.fn((handler) => {
+          messageHandler = handler;
+        }),
+        postMessage: jest.fn(),
+      },
+    };
+
+    (workspace.getConfiguration as jest.Mock).mockReturnValue(config);
+    (workspace.onDidChangeConfiguration as jest.Mock).mockImplementation((handler) => {
+      configChangeHandler = handler;
+      return { dispose: jest.fn() };
+    });
+    (commands.registerCommand as jest.Mock).mockImplementation((command, handler) => {
+      registeredCommands.set(command, handler);
+      return { dispose: jest.fn() };
+    });
+    (window.createWebviewPanel as jest.Mock).mockReturnValue(panel);
+    (window.showInformationMessage as jest.Mock).mockResolvedValue(undefined);
+
+    activate({
+      extensionMode: 2,
+      extensionPath: '/fake/ext',
+      globalState: {
+        get: jest.fn(() => '3.2.0'),
+        update: jest.fn(),
+      },
+      subscriptions: [],
+    } as never);
+
+    expect(applyUserButtonIcon).not.toHaveBeenCalled();
+    expect(resetUserButtonIcon).not.toHaveBeenCalled();
+    expect(applyUserButtonName).not.toHaveBeenCalled();
+    expect(applyButtonManifest).not.toHaveBeenCalled();
+
+    configChangeHandler?.({
+      affectsConfiguration: (section: string) =>
+        section === 'ShortcutMenuBarPlus.userButton01Icon' ||
+        section === 'ShortcutMenuBarPlus.userButton01Name' ||
+        section === 'ShortcutMenuBarPlus.userButton01Command',
+    });
+
+    expect(applyUserButtonIcon).not.toHaveBeenCalled();
+    expect(resetUserButtonIcon).not.toHaveBeenCalled();
+    expect(applyUserButtonName).not.toHaveBeenCalled();
+    expect(applyButtonManifest).not.toHaveBeenCalled();
+    expect(window.showInformationMessage).not.toHaveBeenCalled();
+
+    registeredCommands.get('ShortcutMenuBarPlus.configureButtons')?.();
+    await messageHandler?.({
+      type: 'save',
+      buttons: [
+        {
+          id: 'userButton01',
+          type: 'user',
+          enabled: true,
+          command: 'workbench.action.showCommands',
+          label: 'Commands',
+          icon: 'tools',
+        },
+      ],
+    });
+
+    expect(config.update).toHaveBeenCalledWith(
+      'buttons',
+      expect.any(Array),
+      expect.any(Number)
+    );
+    expect(applyUserButtonIcon).not.toHaveBeenCalled();
+    expect(resetUserButtonIcon).not.toHaveBeenCalled();
+    expect(applyUserButtonName).not.toHaveBeenCalled();
+    expect(applyButtonManifest).not.toHaveBeenCalled();
+    expect(panel.webview.postMessage).toHaveBeenCalledWith({
+      type: 'saved',
+      needsReload: false,
+    });
   });
 
   it('resets generated icons and prompts reload when a legacy icon setting is cleared', () => {

--- a/tests/extensionConfigurator.test.ts
+++ b/tests/extensionConfigurator.test.ts
@@ -162,6 +162,7 @@ describe('extension configurator integration', () => {
 
   it('does not mutate package or icon files while running from the extension development host', async () => {
     let buttonsValue: unknown;
+    let legacyCommand = 'workbench.action.showCommands';
     const config = {
       inspect: jest.fn(() =>
         buttonsValue === undefined
@@ -177,6 +178,9 @@ describe('extension configurator integration', () => {
         }
         if (key === 'userButton01Name') {
           return 'Dev Name';
+        }
+        if (key === 'userButton01Command') {
+          return legacyCommand;
         }
         return undefined;
       }),
@@ -242,6 +246,25 @@ describe('extension configurator integration', () => {
     expect(applyUserButtonName).not.toHaveBeenCalled();
     expect(applyButtonManifest).not.toHaveBeenCalled();
     expect(window.showInformationMessage).not.toHaveBeenCalled();
+
+    registeredCommands.get('ShortcutMenuBarPlus.userButton01')?.();
+    expect(commands.executeCommand).toHaveBeenLastCalledWith(
+      'workbench.action.showCommands'
+    );
+
+    legacyCommand = 'workbench.action.quickOpen';
+    configChangeHandler?.({
+      affectsConfiguration: (section: string) =>
+        section === 'ShortcutMenuBarPlus.userButton01Command',
+    });
+    registeredCommands.get('ShortcutMenuBarPlus.userButton01')?.();
+    expect(commands.executeCommand).toHaveBeenLastCalledWith(
+      'workbench.action.quickOpen'
+    );
+    expect(applyUserButtonIcon).not.toHaveBeenCalled();
+    expect(resetUserButtonIcon).not.toHaveBeenCalled();
+    expect(applyUserButtonName).not.toHaveBeenCalled();
+    expect(applyButtonManifest).not.toHaveBeenCalled();
 
     registeredCommands.get('ShortcutMenuBarPlus.configureButtons')?.();
     await messageHandler?.({


### PR DESCRIPTION
## Summary
Stops VS Code Extension Development Host runs from dirtying tracked repo files while preserving the existing runtime manifest/icon rewrite behavior for installed extension builds.

## What Changed
- Detects `ExtensionMode.Development` during activation and skips startup/config-change writes to `package.json` and generated `images/userButtonXX*.svg` files.
- Passes the same mutation guard into the button configurator so development-host saves still persist settings without applying package/icon/manifest file rewrites or prompting reload.
- Adds configurator integration coverage proving dev-host activation, legacy setting changes, and configurator saves do not call the manifest/icon/name mutation helpers.

## Why
Manual extension development runs were changing the working tree by rewriting `package.json` and generated SVG assets. Those writes are still needed for installed/package behavior, but they should not happen when the extension is launched from the source repo for development.

## Validation
- `npm test -- --runInBand`
- `npm run compile`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extension behavior now adapts based on development vs. production mode; in production, file mutations for icons, names, and manifests are restricted.

* **Tests**
  * Added integration tests validating extension behavior in development mode with configuration changes and save operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snuffy2/shortcut-menu-bar-plus/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->